### PR TITLE
Set tls-cert-bundle

### DIFF
--- a/rootfs/etc/unbound/unbound.conf
+++ b/rootfs/etc/unbound/unbound.conf
@@ -33,5 +33,7 @@ server:
 
   identity: "docker-unbound"
   auto-trust-anchor-file: "/var/run/unbound/root.key"
+  
+  tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
 
   include: "/config/*.conf"


### PR DESCRIPTION
Set tls-cert-bundle to enable SSL handshakes. E.g. for upstream DNS-over-TLS (DoT)

Fix for issue #28 